### PR TITLE
Add `Accept-Language` header to `fetchFromUrl`

### DIFF
--- a/ext/src/js/classes/simulcast_calendar_fetcher.js
+++ b/ext/src/js/classes/simulcast_calendar_fetcher.js
@@ -142,7 +142,12 @@ export default class SimulcastCalendarFetcher {
      */
     async fetchFromUrl(url) {
         try {
-            const response = await fetch(url, {credentials: 'omit'});
+            const response = await fetch(url, {
+                credentials: 'omit',
+                headers: {
+                    "Accept-Language": "en-US,en;q=0.9"
+                }
+            });
             const html = await response.text();
             const parser = new DOMParser();
             const doc = parser.parseFromString(html, 'text/html');

--- a/ext/src/manifest.json
+++ b/ext/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Release Calendar Filter for Crunchyroll",
   "description": "A filter for the Release/Simulcast Calendar on Crunchyroll.",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "icons": {
     "128": "images/icon.png"
   },

--- a/ext/src_firefox/manifest.json
+++ b/ext/src_firefox/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Release Calendar Filter for Crunchyroll",
   "description": "A filter for the Release/Simulcast Calendar on Crunchyroll.",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "icons": {
     "128": "images/icon.png"
   },


### PR DESCRIPTION
[`ext/src/js/classes/simulcast_calendar_fetcher.js`](diffhunk://#diff-bedad6c86502000f85b16cf6f2689e6c4a616506264fe708e6d72e1181c50d62L145-R150): The `fetchFromUrl` method now sets the `Accept-Language` header to prefer English when fetching calendar data. This helps ensure consistent language in the fetched content. For #32