### PR TITLE
Season title handling improvements

### DIFF
--- a/ext/src/js/classes/content.js
+++ b/ext/src/js/classes/content.js
@@ -90,6 +90,7 @@ export default class Content {
     }
 
     #parseContent(content, tinyContents) {
+        let shouldSeasonTitleBeModified = false;
         const releaseArticle = content.querySelector("article.js-release");
 
         const releaseArticleDataset = releaseArticle.dataset;
@@ -129,6 +130,7 @@ export default class Content {
         const seasonH1 = releaseArticle.querySelector("h1.season-name");
         const seasonUrl = seasonH1.querySelector("a");
         this.#seasonTitle = seasonUrl.querySelector("cite").textContent;
+        const originalSeasonTitle = this.#seasonTitle;
 
         if (tinyContents) {
             const popoverId = getPopoverID(releaseArticleDataset);
@@ -136,8 +138,10 @@ export default class Content {
                 // Find the TinyContent object with the matching popoverId
                 const tinyContent = tinyContents.find(tc => tc.popoverId === popoverId);
                 if (tinyContent) {
+                    shouldSeasonTitleBeModified = true;
                     // console.log(`TinyContent found: ${tinyContent.blurb()}`);
                     // season name
+                    //console.log(`Replacing season title with TinyContent: ${tinyContent.seasonTitle}, original: ${this.#seasonTitle}`);
                     this.#seasonTitle = tinyContent.seasonTitle;
                 } else {
                     console.warn(`TinyContent with popoverId ${popoverId} not found.`);
@@ -146,7 +150,16 @@ export default class Content {
         }
 
         // console.log(`Starting name check with season title: ${this.#seasonTitle}`);
-        seasonUrl.querySelector("cite").textContent = this.#seasonTitle;
+
+        if (shouldSeasonTitleBeModified) {
+            console.log(`Restore needed for ${this.#seasonTitle}`);
+            // If the season title does not start with the original season title, restore it
+            if (!this.#seasonTitle.startsWith(originalSeasonTitle)) {
+                seasonUrl.querySelector("cite").textContent = originalSeasonTitle;
+            } else {
+                seasonUrl.querySelector("cite").textContent = this.#seasonTitle;
+            }
+        }
 
         // dub info
         const found = this.#seasonTitle.match(Content.#regexp);
@@ -205,6 +218,7 @@ export default class Content {
                 this.#forceShowInSubOnlyAlso = true;
             }
         }
+
 
         // progress bar
         const currentProgress = releaseArticle.querySelector("progress");

--- a/ext/src/manifest.json
+++ b/ext/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Release Calendar Filter for Crunchyroll",
   "description": "A filter for the Release/Simulcast Calendar on Crunchyroll.",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "icons": {
     "128": "images/icon.png"
   },

--- a/ext/src_firefox/manifest.json
+++ b/ext/src_firefox/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Release Calendar Filter for Crunchyroll",
   "description": "A filter for the Release/Simulcast Calendar on Crunchyroll.",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "icons": {
     "128": "images/icon.png"
   },


### PR DESCRIPTION
Improved the logic in `Content.#parseContent` so that when a TinyContent object modifies the season title, the code now checks if the new title starts with the original season title; if not, it restores the original title to prevent incorrect overwrites. [[1]](diffhunk://#diff-e96edcba5af6e89fcc1aecf8c806f3b0f06b02b447bc147d1366ea19a060bdbfR93) [[2]](diffhunk://#diff-e96edcba5af6e89fcc1aecf8c806f3b0f06b02b447bc147d1366ea19a060bdbfR133-R144) [[3]](diffhunk://#diff-e96edcba5af6e89fcc1aecf8c806f3b0f06b02b447bc147d1366ea19a060bdbfR153-R162)